### PR TITLE
Renormalize X after selecting the correct key frames.

### DIFF
--- a/mapper.js
+++ b/mapper.js
@@ -83,16 +83,13 @@ module.exports = function(RED) {
         {
             let y = x
             let normalizedX = normalize(x, node.inputFrom, node.inputTo);
-            for(var i = 0; i < node.keyframes.length; i++)
+            for(var i = 1; i < node.keyframes.length; i++)
             {
-                if( i === 0 )
-                    continue;
-
                 if( (normalizedX < node.keyframes[i].x) || (( i === node.keyframes.length-1) && normalizedX === node.keyframes[i].x) )
                 {
                     var startKeyframe = node.keyframes[i-1];
                     var endKeyframe = node.keyframes[i];
-                    y = interpolateLinear(startKeyframe.y, endKeyframe.y, normalizedX);
+                    y = interpolateLinear(startKeyframe.y, endKeyframe.y, normalize(normalizedX, startKeyframe.x, endKeyframe.x) );
                     break;
                 }
             }
@@ -114,6 +111,7 @@ module.exports = function(RED) {
                 return 0;
             return (x-min)/(max-min);
         }
+
         function interpolateLinear(a, b, x) {
             return ((b * x)+(a * (1-x)));
         }


### PR DESCRIPTION
I really like the graphical editor for the mapping, but, well, no way to put it nicely, the calculation was unfortunately wrong. This PR fixes the calculation.

X is normalized on the full X range to select the key frames.
The way the Y value is interpolated between key frames requires the X value to be between 0 (left key frame) and 1 (right key frame).
Therefore it must be renormalized from the full range to the range between key frames.